### PR TITLE
Add definitions of ready and done

### DIFF
--- a/Definitions.md
+++ b/Definitions.md
@@ -1,0 +1,16 @@
+# FE Definition of Ready
+- Estimated
+- Below 13 points
+- Concise and unambiguous single-sentence description
+- An additional paragraph or less describing the task if necessary
+- Linked to an epic
+- Task's scope refers to UI *or* logic, not both
+
+# FE Definition of Done
+- Feature implemented according to description of task
+- Code compiles
+- Code passes any existing tests
+- Work submitted with additional logic tests where needed
+- UI task does not contain logic, and vice versa
+- No external dependencies that violate any licenses
+- 500 line limit per pull request

--- a/Definitions.md
+++ b/Definitions.md
@@ -13,4 +13,4 @@
 - Work submitted with additional logic tests where needed
 - UI task does not contain logic, and vice versa
 - No external dependencies that violate any licenses
-- 500 line limit per pull request
+- 500 line limit per pull request, or a good reason for exceeding the limit


### PR DESCRIPTION
Both definitions are in the same document for now (`Definitions.md`); once we're all happy with them, I'll separate them into their own files.

Please use the discussions feature to suggest any feedback.